### PR TITLE
Add optional config key 'unhead'; Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,22 @@ export default defineNuxtConfig({
   ],
 })
 ```
+## Module Configuration
 
+Config key: `unhead`
+
+_nuxt.config.ts_
+
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-unhead'],
+
+  unhead: {
+    // config (see below)
+  },
+  //...
+})
+```
 
 ## Config
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -13,8 +13,12 @@ export default defineNuxtConfig({
       viewport: 'width=device-width, initial-scale=1',
     },
   },
+
+  unhead: {},
+
   workspaceDir: resolve(__dirname, '../'),
   imports: {
     autoImport: true,
   },
 })
+

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,7 +27,7 @@ export interface ModuleOptions {
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-unhead',
-    configKey: 'unhead',
+    configKey: 'head',
     compatibility: {
       nuxt: '^3.0.0',
     },
@@ -40,6 +40,8 @@ export default defineNuxtModule<ModuleOptions>({
   },
   async setup(options, nuxt) {
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
+
+    options = Object.assign({}, options, nuxt.options.unhead)
 
     addTemplate({
       filename: 'nuxt-unhead-config.mjs',

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,7 +27,7 @@ export interface ModuleOptions {
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-unhead',
-    configKey: 'head',
+    configKey: 'unhead',
     compatibility: {
       nuxt: '^3.0.0',
     },

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,19 +9,19 @@ export interface ModuleOptions {
   /**
    * Whether meta tags should be optimised for SEO.
    */
-  seoOptimise: boolean
+  seoOptimise?: boolean
   /**
    * Allows you to resolve aliasing when linking internal files.
    */
-  resolveAliases: boolean
+  resolveAliases?: boolean
   /**
    * The template used to render the og:title. Use %s to insert the og:title.
    */
-  ogTitleTemplate: string
+  ogTitleTemplate?: string
   /**
    * The template used to render the og:title. Use %s to insert the og:description.
    */
-  ogDescriptionTemplate: string
+  ogDescriptionTemplate?: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -82,3 +82,13 @@ export default defineNuxtModule<ModuleOptions>({
     addPlugin({ src: resolve(runtimeDir, 'plugin') })
   },
 })
+
+
+declare module '@nuxt/schema' {
+  interface NuxtConfig {
+    unhead?: ModuleOptions
+  }
+  interface NuxtOptions {
+    unhead?: ModuleOptions
+  }
+}


### PR DESCRIPTION
add "Module Configuration" section in README.md


### Description

The nuxt config is set to 'head' but actually in README you can find that it should be 'unhead'.

![image](https://user-images.githubusercontent.com/11756007/213337432-c2c8eb2a-89a8-4627-abe3-85dd957c24aa.png)


### Linked Issues

_no_

### Additional context

_no_
